### PR TITLE
Makefile installs unnecessary dependencies in python.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 install:
-	pip install -r requirements.txt
+	pip3 install -r requirements.txt
 	wget --no-check-certificate https://github.com/neologd/mecab-ipadic-neologd/tarball/master -O mecab-ipadic-neologd.tar
 	tar -xvf mecab-ipadic-neologd.tar
 	xz -dc ./neologd-mecab-ipadic-neologd-*/seed/mecab-user-dict-seed.*.csv.xz > ./mecab-user-dict-seed.csv


### PR DESCRIPTION
https://github.com/fumankaitori/neologd2juman/blob/de72e6afa987a11ec45765483cc74111546aa11f/neologd2juman.sh#L52-L61

In neologd2juman.sh, `python3` is called, not `python`.

In most cases, the package management system that supports `python3` is considered to be `pip3`. `pip` supports `python`.

https://github.com/fumankaitori/neologd2juman/blob/de72e6afa987a11ec45765483cc74111546aa11f/Makefile#L2

Therefore, the Makefile in this project uses `pip`, which I think installs an unnecessary dependency in `python`. 
I think it should be changed to `pip3` to properly install in `python3`. 