### PR TITLE
use jaconvV2.is_han to exclude Hankaku so that juman/makeint won't exit with error code 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ install:
 	tar -xvf mecab-ipadic-neologd.tar
 	xz -dc ./neologd-mecab-ipadic-neologd-*/seed/mecab-user-dict-seed.*.csv.xz > ./mecab-user-dict-seed.csv
 	bash neologd2juman.sh mecab-user-dict-seed.csv
-	bash install-dictionary.sh
-	mv mecab-user-dict-seed.csv.dic neologd-user-dict.dic
+	sudo bash install-dictionary.sh
+	sudo mv mecab-user-dict-seed.csv.dic neologd-user-dict.dic
 
 clean:
 	rm mecab-ipadic-neologd.tar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jaconv
+jaconvV2


### PR DESCRIPTION
- Makefile needs sudo priviledge
-  remove midasi that contains Hankaku so that juman/makeint will not exit with error code 5